### PR TITLE
Some new ideas for how to initialize the App

### DIFF
--- a/lib/tap_watir.rb
+++ b/lib/tap_watir.rb
@@ -1,15 +1,39 @@
 require "watir"
+require 'appium_lib_core'
 
 module TapWatir
   class App
-    def self.browser(opts)
-      MobileBrowser.new opts
+    # What ruby_lib_core expects
+    #     opts = {
+    #              caps: {
+    #                platformName: :ios,
+    #                platformVersion: '11.0',
+    #                deviceName: 'iPhone Simulator',
+    #                automationName: 'XCUITest',
+    #                app: '/path/to/MyiOS.app'
+    #              },
+    #              appium_lib: {
+    #                server_url: "http://custom-host:8080/wd/hub.com",
+    #                export_session: false,
+    #                port: 8080,
+    #                wait: 0,
+    #                wait_timeout: 20,
+    #                wait_interval: 0.3,
+    #                listener: nil,
+    #              }
+    #            }
+
+    def initialize(opts)
+      # What is `target` here?
+      # Is this even the right class to initialize?
+      @driver = Appium::Core::Driver.for(self, opts).start_driver
     end
+
   end
 
   class MobileBrowser < Watir::Browser
     def initialize(opts)
-      super Selenium::WebDriver.for(:remote, opts)
+      @browser = super Selenium::WebDriver.for(:remote, opts)
     end
   end
 end

--- a/spec/tap_watir_spec.rb
+++ b/spec/tap_watir_spec.rb
@@ -1,14 +1,40 @@
 RSpec.describe TapWatir do
-  it "opens Chrome" do
-    appium_url = 'http://localhost:4723/wd/hub'
-    caps = {platformName: 'Android',
-            platformVersion: '8.1',
-            deviceName: 'Nexus',
-            browserName: 'Chrome'}
+  context "with Android" do
+    it "opens Browser on Mobile Device" do
+      opts = {url: 'http://localhost:4723/wd/hub',
+              platformName: 'Android',
+              platformVersion: '8.1',
+              deviceName: 'Nexus',
+              browserName: 'Chrome'}
 
-    browser = TapWatir::App.browser(url: appium_url, desired_capabilities: caps)
-    browser.goto "http://watir.com/"
-    expect(browser.url).to eq "http://watir.com/"
-    browser.close
+      browser = TapWatir::MobileBrowser.new(opts)
+      browser.goto "http://watir.com/"
+      expect(browser.url).to eq "http://watir.com/"
+      browser.close
+    end
+
+    xit "opens Native App Locally" do
+      opts = {url: 'http://localhost:4723/wd/hub',
+              platformName: "Android",
+              platformVersion: "8.1",
+              deviceName: "Nexus",
+              app: "https://github.com/address-book/mobile_apps/blob/master/AddressBook.apk?raw=true",
+              appWaitActivity: "com.address.book.MainActivity",
+      }
+      app = TapWatir::App.new(opts)
+      expect(app.driver).to be_a(Appium::Driver)
+      app.quit
+    end
+
+    xit "opens Native App EmuSim"
+    xit "opens Native App Real Device Cloud"
   end
+
+  context "with iOS" do
+    xit "opens Browser on Mobile Device"
+    xit "opens Native App Locally"
+    xit "opens Native App EmuSim"
+    xit "opens Native App Real Device Cloud"
+  end
+
 end

--- a/tap_watir.gemspec
+++ b/tap_watir.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency 'watir', '~> 6.0'
+  spec.add_dependency 'appium_lib_core', '~> 1.0'
 end


### PR DESCRIPTION
So I'm thinking we want to open a browser on a mobile device differently from how we open an application:

`TapWatir::MobileBrowser.new(opts)`
vs.
`TapWatir::App.new(opts)`

Also thinking we should move away from the idea of `caps` and just put everything into a single Hash input for now.

In the future we might want to create some kind of `Capabilities` object to make things more strict.