### PR TITLE
use appium core 2.x and remove self

### DIFF
--- a/lib/tap_watir.rb
+++ b/lib/tap_watir.rb
@@ -14,7 +14,7 @@ module TapWatir
 
     def initialize(opts)
       url = opts[:caps].delete(:url)
-      @driver = Appium::Core.for(self, opts).start_driver(server_url: url)
+      @driver = Appium::Core.for(opts).start_driver(server_url: url)
     end
 
     def quit

--- a/tap_watir.gemspec
+++ b/tap_watir.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.50'
 
-  spec.add_dependency 'appium_lib_core', '~> 1.0'
+  spec.add_dependency 'appium_lib_core', '~> 2.0'
   spec.add_dependency 'watir', '~> 6.0'
 end


### PR DESCRIPTION
In https://github.com/appium/ruby_lib_core/pull/136 , I've got rid of `self` from initialisation of appium core.
A user who only uses the core library, we no longer set `self` as the argument.